### PR TITLE
Adding error message for bad header

### DIFF
--- a/src/itchio/game.py
+++ b/src/itchio/game.py
@@ -60,8 +60,22 @@ class Game:
             # response_code = urllib.request.urlopen(url).getcode()
             try:
                 itchio.utils.download(url, path, self.name +" - "+file)
+            except TypeError as e:
+                print("This one has broken due to a missing header!!")
+
+                with open('errors.txt', 'a') as f:
+                    f.write(f""" Cannot download game/asset: {self.game_slug}
+                    Publisher Name: {self.publisher_slug}
+                    Path: {path}
+                    File: {file}
+                    Request URL: {url}
+                    This request failed due to a missing response header
+                    This game/asset has been skipped please download manually
+                    ---------------------------------------------------------\n """)
+                
+                continue
             except urllib.error.HTTPError as e:
-                print("This one has broken!!")
+                print("This one has broken due to a HTTP error!!")
 
                 with open('errors.txt', 'a') as f:
                     f.write(f""" Cannot download game/asset: {self.game_slug}


### PR DESCRIPTION
Hi, I created this quick patch for the bug here: https://github.com/Emersont1/itchio/issues/14

In short, there are some games that seem to be returning empty "Content-Disposition" headers when downloading. I just added some error handling/logging to skip these games so that you can continue the download (this has worked for me so far), copying the strategy that was used for HTTP errors.

There may be a better way of handling this header problem, in which case feel free to reject this pull request! Thanks for the work on the tool!