### PR TITLE
Verbose Folders Argument (And Others)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,11 +25,20 @@ python -m itchiodl.downloader --api-key=KEYHERE --jobs=4
 # via setup-tools entry point
 itch-download -k KEYHERE
 
-# download with multiple threads
+# download with multiple threads, default is 4 if unspecified
 itch-download -k KEYHERE -j 4
 
 # only download osx or cross platform downloads
 itch-download -p osx
+
+# folder structure uses display names for users/publishers and game titles
+itch-download -vf
+
+# skips downloads above a certain size in megabytes, supports decimals
+itch-download -sas 50.0
+
+# verifies downloads and creates an additional .md5 file for each download
+itch-download -v
 ```
 
 ## Add All Games in a bundle to your library

--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ itch-download --download-publisher
 itch-download --download-game
 
 # For the --download-game argument, skips the check to see if the title is currently owned
-# In practice this free files only
+# In practice this downloads free files only
 itch-download --skip-library-load
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,24 @@ itch-download -vf
 # skips downloads above a certain size in megabytes, supports decimals
 itch-download -sas 50.0
 
-# verifies downloads and creates an additional .md5 file for each download
-itch-download -v
+# Disables file verification entirely, files with the same name are assumed to be the same file
+itch-download --no-verify
+
+# Disables writing supplementary .md5 files, existing files will still be hashed against their download hashes
+# Does nothing if --no-verify is specified
+itch-download --no-verify-file
+
+# Downloads all free titles from the specified publisher
+# Argument should be formatted 'https://{publisher}.itch.io'
+itch-download --download-publisher
+
+# Checks if title is owned, then downloads all files for it
+# Argument should be formatted 'https://{publisher}.itch.io/{title}/'
+itch-download --download-game
+
+# For the --download-game argument, skips the check to see if the title is currently owned
+# In practice this free files only
+itch-download --skip-library-load
 ```
 
 ## Add All Games in a bundle to your library

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -29,7 +29,6 @@ def main():
     )
 
     parser.add_argument(
-        "-v",
         "--verify",
         type=bool,
         default=False,
@@ -82,8 +81,16 @@ def main():
     if args.download_publisher:
         lib.load_games(args.download_publisher)
     elif args.download_game:
-        matches = re.match(r"https://(.+)\.itch\.io/(.+)", args.download_game)
-        lib.load_game(matches.group(1), matches.group(2))
+        lib.load_owned_games()
+        for game in lib.games:
+            if game.link == args.download_game:
+                lib.games = [game]
+                break
+        if len(lib) > 1:
+            print("Game Is Not In Library, terminating")
+            return -1
+#        matches = re.match(r"https://(.+)\.itch\.io/(.+)", args.download_game)
+#        lib.load_game(matches.group(1), matches.group(2))
     else:
         lib.load_owned_games()
 

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -38,7 +38,7 @@ def main():
         "-j",
         "--jobs",
         type=int,
-        default=4,
+        default=1,
         help="Number of concurrent downloads, defaults to 4",
     )
 

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -87,10 +87,12 @@ def main():
                 lib.games = [game]
                 break
         if len(lib) > 1:
-            print("Game Is Not In Library, terminating")
-            return -1
-#        matches = re.match(r"https://(.+)\.itch\.io/(.+)", args.download_game)
-#        lib.load_game(matches.group(1), matches.group(2))
+            print("Game Is Not In Library, Checking for Free Downloads")
+            lib.games = []
+            matches = re.match(r"https://(.+)\.itch\.io/(.+)", args.download_game)
+            lib.load_game(matches.group(1), matches.group(2))
+
+
     else:
         lib.load_owned_games()
 

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -19,6 +19,22 @@ def main():
     )
 
     parser.add_argument(
+        "-vf",
+        "--verbose-folders",
+        type=bool,
+        default=False,
+        help="Download Folders are named based on the full text version of the title instead of the trimmed URL title"
+    )
+
+    parser.add_argument(
+        "-sas",
+        "--skip-above-size",
+        type=float,
+        default=float('inf'),
+        help="Skips individual files that are above the specified size threshold, size in MB"
+    )
+
+    parser.add_argument(
         "-j",
         "--jobs",
         type=int,
@@ -41,6 +57,10 @@ def main():
     args = parser.parse_args()
 
     l = ""
+    global SkipAboveSize
+    SkipAboveSize = args.skip_above_size
+    global VerboseFolders
+    VerboseFolders = args.verbose_folders
 
     if not args.api_key:
         user = input("Username: ")

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -23,7 +23,19 @@ def main():
         "--verbose-folders",
         type=bool,
         default=False,
+        const=True,
+        nargs='?',
         help="Download Folders are named based on the full text version of the title instead of the trimmed URL title"
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verify",
+        type=bool,
+        default=False,
+        const=True,
+        nargs='?',
+        help="Verifies each file downloaded and produces a supplementary checksum file"
     )
 
     parser.add_argument(
@@ -31,14 +43,14 @@ def main():
         "--skip-above-size",
         type=float,
         default=float('inf'),
-        help="Skips individual files that are above the specified size threshold, size in MB"
+        help="Skips individual files that are above the specified size threshold, size in MB, supports decimals"
     )
 
     parser.add_argument(
         "-j",
         "--jobs",
         type=int,
-        default=1,
+        default=4,
         help="Number of concurrent downloads, defaults to 4",
     )
 
@@ -57,10 +69,6 @@ def main():
     args = parser.parse_args()
 
     l = ""
-    global SkipAboveSize
-    SkipAboveSize = args.skip_above_size
-    global VerboseFolders
-    VerboseFolders = args.verbose_folders
 
     if not args.api_key:
         user = input("Username: ")

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -171,7 +171,6 @@ class Game:
                 + f"download?api_key={token}&download_key_id={self.id}&uuid={j['uuid']}"
             )
         else:
-            print("!! NO DOWNLOAD KEY !!")
             url = (
                 f"https://api.itch.io/uploads/{d['id']}/"
                 + f"download?api_key={token}&uuid={j['uuid']}"

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -18,7 +18,7 @@ class Game:
         self.id = False
         self.game_id = None
         self.args = sys.argv[1:]
-        if '-vf' or '--verbose-folders' in self.args:
+        if '-vf' in self.args or '--verbose-folders' in self.args:
             self.verbose = True
         else:
             self.verbose = False
@@ -46,19 +46,19 @@ class Game:
 
         self.data = data["game"]
 
+        self.link = self.data["url"]
+        matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
+        self.game_slug = matches.group(2)
+
         if self.verbose:
             self.name = itchiodl.utils.clean_path(self.data["title"])
             self.publisher = self.data.get("user").get("display_name")
             if not self.publisher:
                 self.publisher = self.data.get("user").get("username")
         else:
-            self.name = self.data["title"]
+            self.name = self.game_slug
             self.publisher = self.data.get("user").get("username")
 
-        self.link = self.data["url"]
-
-        matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
-        self.game_slug = matches.group(2)
         self.publisher_slug = itchiodl.utils.clean_path(self.publisher)
 
         self.destination_path = os.path.normpath(f"{self.publisher_slug}/{self.name}")

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -29,6 +29,13 @@ class Game:
         self.game_slug = matches.group(2)
         self.publisher_slug = matches.group(1)
 
+        if "VerboseFolders" in globals():
+            self.destination_folder = self.game_slug if not VerboseFolders else self.name
+        else:
+            self.destination_folder = self.game_slug
+            print("VerboseFolders Not Detected in Global Variables, Falling Back to Game Slug\n")
+        self.destination_path = itchiodl.utils.clean_path(f"{self.publisher_slug}/{self.destination_folder}")
+
         self.files = []
         self.downloads = []
 
@@ -62,8 +69,8 @@ class Game:
         if not os.path.exists(self.publisher_slug):
             os.mkdir(self.publisher_slug)
 
-        if not os.path.exists(f"{self.publisher_slug}/{self.game_slug}"):
-            os.mkdir(f"{self.publisher_slug}/{self.game_slug}")
+        if not os.path.exists(self.destination_path):
+            os.mkdir(self.destination_path)
 
         for d in self.downloads:
             if (
@@ -75,7 +82,7 @@ class Game:
                 continue
             self.do_download(d, token)
 
-        with open(f"{self.publisher_slug}/{self.game_slug}.json", "w") as f:
+        with open(f"{self.destination_path}.json", "w") as f:
             json.dump(
                 {
                     "name": self.name,
@@ -94,7 +101,7 @@ class Game:
         print(f"Downloading {d['filename']}")
 
         file = itchiodl.utils.clean_path(d["filename"] or d["display_name"] or d["id"])
-        path = itchiodl.utils.clean_path(f"{self.publisher_slug}/{self.game_slug}")
+        path = self.destination_path
 
         if os.path.exists(f"{path}/{file}"):
             print(f"File Already Exists! {file}")

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -42,7 +42,7 @@ class Game:
             self.skipping_above_size_MB = float(self.args[(self.args.index('--skip-above-size')+1)])
             self.skipping_above_size_B = abs(self.skipping_above_size_MB * 1000000)
         else:
-            self.skipping_above_size = False
+            self.skipping_large_entries = False
 
         self.data = data["game"]
 

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -29,12 +29,12 @@ class Game:
         self.game_slug = matches.group(2)
         self.publisher_slug = matches.group(1)
 
-        if "VerboseFolders" in globals():
-            self.destination_folder = self.game_slug if not VerboseFolders else self.name
-        else:
-            self.destination_folder = self.game_slug
-            print("VerboseFolders Not Detected in Global Variables, Falling Back to Game Slug\n")
-        self.destination_path = itchiodl.utils.clean_path(f"{self.publisher_slug}/{self.destination_folder}")
+        #if "VerboseFolders" in globals():
+        #    self.destination_folder = self.game_slug if not VerboseFolders else self.name
+        #else:
+        #    self.destination_folder = self.game_slug
+        #    print("VerboseFolders Not Detected in Global Variables, Falling Back to Game Slug\n")
+        self.destination_path = itchiodl.utils.clean_path(f"{self.publisher_slug}/{self.name}")
 
         self.files = []
         self.downloads = []

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -57,7 +57,7 @@ class Game:
                 self.publisher = self.data.get("user").get("username")
         else:
             self.name = self.game_slug
-            self.publisher = self.data.get("user").get("username")
+            self.publisher = matches.group(1)
 
         self.publisher_slug = itchiodl.utils.clean_path(self.publisher)
 

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -70,12 +70,15 @@ class Game:
             )
         j = r.json()
         for d in j["uploads"]:
-            if not self.skipping_above_size:
-                self.downloads.append(d)
-            elif d["size"] <= self.skipping_above_size_B and self.skipping_large_entries:
-                self.downloads.append(d)
-            else:
-                print("!Skipping Large Item!")
+            try:
+                if not self.skipping_large_entries:
+                    self.downloads.append(d)
+                elif self.skipping_above_size_B > d.get("size"):
+                    self.downloads.append(d)
+                else:
+                    print("!Skipping Large Item!")
+            except:
+                print("There was an Error")
 
     def download(self, token, platform):
         """Download a singular file"""

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -158,6 +158,7 @@ class Game:
                     shutil.move(f"{path}/{file}", f"{path}/old/{timestamp}-{file}")
             else:
                 print(f"File Already Exists! Skipping")
+                return
 
         # Get UUID
         r = requests.post(

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -15,26 +15,22 @@ class Game:
 
     def __init__(self, data):
         self.data = data["game"]
-        self.name = self.data["title"]
+        self.name = itchiodl.utils.clean_path(self.data["title"])
         self.publisher = self.data.get("user").get("display_name")
+        if not self.publisher:
+            self.publisher = self.data.get("user").get("username")
         self.link = self.data["url"]
-        #if "game_id" in self.data:
-        #    self.id = self.data["id"]
-        #    self.game_id = self.data["game_id"]
-        #else:
-        #    self.id = False
-        #    self.game_id = self.data["id"]
 
         matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
         self.game_slug = matches.group(2)
-        self.publisher_slug = self.publisher
+        self.publisher_slug = itchiodl.utils.clean_path(self.publisher)
 
         #if "VerboseFolders" in globals():
         #    self.destination_folder = self.game_slug if not VerboseFolders else self.name
         #else:
         #    self.destination_folder = self.game_slug
         #    print("VerboseFolders Not Detected in Global Variables, Falling Back to Game Slug\n")
-        self.destination_path = itchiodl.utils.clean_path(f"{self.publisher_slug}/{self.name}")
+        self.destination_path = os.path.normpath(f"{self.publisher_slug}/{self.name}")
 
         self.files = []
         self.downloads = []
@@ -60,17 +56,10 @@ class Game:
         """Download a singular file"""
         print("Downloading", self.name)
 
-        # if os.path.exists(f"{self.publisher_slug}/{self.game_slug}.json"):
-        #    print(f"Skipping Game {self.name}")
-        #    return
-
         self.load_downloads(token)
 
-        if not os.path.exists(self.publisher_slug):
-            os.mkdir(self.publisher_slug)
-
         if not os.path.exists(self.destination_path):
-            os.mkdir(self.destination_path)
+            os.makedirs(self.destination_path)
 
         for d in self.downloads:
             if (
@@ -150,6 +139,7 @@ class Game:
                 + f"download?api_key={token}&download_key_id={self.id}&uuid={j['uuid']}"
             )
         else:
+            print("!! NO DOWNLOAD KEY !!")
             url = (
                 f"https://api.itch.io/uploads/{d['id']}/"
                 + f"download?api_key={token}&uuid={j['uuid']}"
@@ -192,10 +182,10 @@ class Game:
             return
 
         # Verify
-        if itchiodl.utils.md5sum(f"{path}/{file}") != d["md5_hash"]:
-            print(f"Failed to verify {file}")
-            return
+        #if itchiodl.utils.md5sum(f"{path}/{file}") != d["md5_hash"]:
+        #    print(f"Failed to verify {file}")
+        #    return
 
         # Create checksum file
-        with open(f"{path}/{file}.md5", "w") as f:
-            f.write(d["md5_hash"])
+        #with open(f"{path}/{file}.md5", "w") as f:
+        #    f.write(d["md5_hash"])

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -80,9 +80,11 @@ class Game:
                 headers={"Authorization": token},
             )
         j = r.json()
+        if j.get("uploads") is None:
+            j.update({"uploads": []})
         for d in j.get("uploads"):
             if d.get("size") is None:
-                d.update("size", 0)
+                d.update({"size": 0})
             if not self.skipping_large_entries:
                 self.downloads.append(d)
             elif self.skipping_above_size_B > d.get("size"):
@@ -225,7 +227,9 @@ class Game:
 
         # Verify
         if self.verify:
-            if itchiodl.utils.md5sum(f"{path}/{file}") != d["md5_hash"]:
+            if itchiodl.utils.md5sum(f"{path}/{file}") != d.get("md5_hash"):
+                if d.get("md5_hash") is None:
+                    return
                 print(f"Failed to verify {file}")
                 return
                 # Create checksum file

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -16,18 +16,18 @@ class Game:
     def __init__(self, data):
         self.data = data["game"]
         self.name = self.data["title"]
-        self.publisher = self.data["user"]["username"]
+        self.publisher = self.data.get("user").get("display_name")
         self.link = self.data["url"]
-        if "game_id" in self.data:
-            self.id = self.data["id"]
-            self.game_id = self.data["game_id"]
-        else:
-            self.id = False
-            self.game_id = self.data["id"]
+        #if "game_id" in self.data:
+        #    self.id = self.data["id"]
+        #    self.game_id = self.data["game_id"]
+        #else:
+        #    self.id = False
+        #    self.game_id = self.data["id"]
 
         matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
         self.game_slug = matches.group(2)
-        self.publisher_slug = matches.group(1)
+        self.publisher_slug = self.publisher
 
         #if "VerboseFolders" in globals():
         #    self.destination_folder = self.game_slug if not VerboseFolders else self.name
@@ -88,7 +88,6 @@ class Game:
                     "name": self.name,
                     "publisher": self.publisher,
                     "link": self.link,
-                    "itch_id": self.id,
                     "game_id": self.game_id,
                     "itch_data": self.data,
                 },

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -121,8 +121,8 @@ class Game:
 
         if os.path.exists(f"{path}/{file}"):
             print(f"File Already Exists! {file}")
-            if os.path.exists(f"{path}/{file}.md5"):
-                if self.verify:
+            if self.verify:
+                if os.path.exists(f"{path}/{file}.md5"):
                     with open(f"{path}/{file}.md5", "r") as f:
                         md5 = f.read().strip()
 
@@ -131,8 +131,7 @@ class Game:
                             return
                         print(f"MD5 Mismatch! {file}")
 
-            else:
-                if self.verify:
+                else:
                     md5 = itchiodl.utils.md5sum(f"{path}/{file}")
                     if md5 == d["md5_hash"]:
                         print(f"Skipping {self.name} - {file}")
@@ -147,13 +146,16 @@ class Game:
                         os.remove(f"{path}/{file}")
                         return
 
-            if not os.path.exists(f"{path}/old"):
-                os.mkdir(f"{path}/old")
+                if not os.path.exists(f"{path}/old"):
+                    os.mkdir(f"{path}/old")
 
-            print(f"Moving {file} to old/")
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d")
-            print(timestamp)
-            shutil.move(f"{path}/{file}", f"{path}/old/{timestamp}-{file}")
+                print(f"Moving {file} to old/")
+                timestamp = datetime.datetime.now().strftime("%Y-%m-%d")
+                print(timestamp)
+                shutil.move(f"{path}/{file}", f"{path}/old/{timestamp}-{file}")
+            else:
+                print(f"Skipping {self.name} - {file}")
+                return
 
         # Get UUID
         r = requests.post(

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import functools
 import threading
 import requests
+import traceback
 from bs4 import BeautifulSoup
 
 from itchiodl.game import Game
@@ -89,9 +90,11 @@ class Library:
                     with lock:
                         with open("errors.txt", "a") as f:
                             f.write(
-                                f""" Cannot download game/asset: {g.name}
-                                This game/asset has been skipped please download manually
-                                ---------------------------------------------------------\n """
+                                f""" An error occurred while downloading: {g.name}\n """
+                            )
+                            traceback.print_exc(file=f)
+                            f.write(
+                                f""" -----------------------------------------------\n  """
                             )
                 finally:
                     with lock:

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -27,6 +27,8 @@ class Library:
 
         for s in j["owned_keys"]:
             self.games.append(Game(s))
+            self.games[-1].id = s["id"]
+            self.games[-1].game_id = s["game_id"]
 
         return len(j["owned_keys"])
 

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -72,6 +72,8 @@ class Library:
             )
             k = json.loads(gsp.text)
             self.games.append(Game(k))
+            self.games[-1].id = False
+            self.games[-1].game_id = k["id"]
 
     def download_library(self, platform=None):
         """Download all games in the library"""

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -7,7 +7,6 @@ from bs4 import BeautifulSoup
 
 from itchiodl.game import Game
 
-
 class Library:
     """Representation of a user's game library"""
 

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -11,7 +11,7 @@ from itchiodl.game import Game
 class Library:
     """Representation of a user's game library"""
 
-    def __init__(self, login, jobs=4):
+    def __init__(self, login, jobs=1):
         self.login = login
         self.games = []
         self.jobs = jobs

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -11,7 +11,7 @@ from itchiodl.game import Game
 class Library:
     """Representation of a user's game library"""
 
-    def __init__(self, login, jobs=1):
+    def __init__(self, login, jobs=4):
         self.login = login
         self.games = []
         self.jobs = jobs

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -57,6 +57,8 @@ class Library:
         )
         k = json.loads(gsp.text)
         self.games.append(Game(k))
+        self.games[-1].id = False
+        self.games[-1].game_id = j["id"]
 
     def load_games(self, publisher):
         """Load all games by publisher"""

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -15,6 +15,9 @@ class Library:
         self.games = []
         self.jobs = jobs
 
+    def __len__(self):
+        return len(self.games)
+
     def load_game_page(self, page):
         """Load a page of games via the API"""
         print("Loading page", page)

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -83,10 +83,20 @@ class Library:
             lock = threading.RLock()
 
             def dl(i, g):
-                x = g.download(self.login, platform)
-                with lock:
-                    i[0] += 1
-                print(f"Downloaded {g.name} ({i[0]} of {l})")
-                return x
+                try:
+                    x = g.download(self.login, platform)
+                except:
+                    with lock:
+                        with open("errors.txt", "a") as f:
+                            f.write(
+                                f""" Cannot download game/asset: {g.name}
+                                This game/asset has been skipped please download manually
+                                ---------------------------------------------------------\n """
+                            )
+                finally:
+                    with lock:
+                        i[0] += 1
+                    print(f"Downloaded {g.name} ({i[0]} of {l})")
+                    return x
 
             executor.map(functools.partial(dl, i), self.games)

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -1,8 +1,6 @@
 import re
-import sys
 import hashlib
 import requests
-import os
 
 
 class NoDownloadError(Exception):

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -2,6 +2,7 @@ import re
 import sys
 import hashlib
 import requests
+import os
 
 
 class NoDownloadError(Exception):
@@ -39,10 +40,10 @@ def download(url, path, name, file):
 
 def clean_path(path):
     """Cleans a path on windows"""
-    if sys.platform in ["win32", "cygwin", "msys"]:
-        path_clean = path.replace(r"[\<\>\:\"\/\\\|\?\*]", "-")
-        return path_clean
-    return path
+    #if sys.platform in ["win32", "cygwin", "msys"]:
+    path_clean = re.sub(r"[\<\>\:\"\/\\\|\?\*]", "-", path)
+    return path_clean
+    #return path
 
 
 def md5sum(path):

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -40,7 +40,7 @@ def download(url, path, name, file):
 def clean_path(path):
     """Cleans a path on windows"""
     if sys.platform in ["win32", "cygwin", "msys"]:
-        path_clean = re.replace(r"[\<\>\:\"\/\\\|\?\*]", "-", path)
+        path_clean = path.replace(r"[\<\>\:\"\/\\\|\?\*]", "-")
         return path_clean
     return path
 

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -1,7 +1,7 @@
 import re
 import hashlib
 import requests
-
+import os.path
 
 class NoDownloadError(Exception):
     """No download found exception"""
@@ -38,10 +38,10 @@ def download(url, path, name, file):
 
 def clean_path(path):
     """Cleans a path on windows"""
-    #if sys.platform in ["win32", "cygwin", "msys"]:
-    path_clean = re.sub(r"[\<\>\:\"\/\\\|\?\*]", "-", path)
+    path_clean = re.sub(r'[<>:"/\\|?*]', "-", path)
+    # This checks for strings that end in ... or similar, weird corner case that affects fewer than 0.1% of titles
+    path_clean = re.sub(r'(.)[.]\1+$', "-", path_clean)
     return path_clean
-    #return path
 
 
 def md5sum(path):

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -24,18 +24,18 @@ def download(url, path, name, file):
 
     cd = rsp.headers.get("Content-Disposition")
 
-    filename_re = re.search(r'filename="(.+)"', cd)
-    if filename_re is None:
-        filename = file
-    else:
-        filename = filename_re.group(1)
+    #filename_re = re.search(r'filename="(.+)"', cd)
+    #if filename_re is None:
+    #    filename = file
+    #else:
+    #    filename = filename_re.group(1)
 
-    with open(f"{path}/{filename}", "wb") as f:
+    with open(f"{path}/{file}", "wb") as f:
         for chunk in rsp.iter_content(10240):
             f.write(chunk)
 
-    print(f"Downloaded {filename}")
-    return f"{path}/{filename}", True
+    print(f"Downloaded {file}")
+    return f"{path}/{file}", True
 
 
 def clean_path(path):


### PR DESCRIPTION
I feel like I've got these changes in a relatively clean spot for review, to summarize:

- added the -vf argument for Verbose Folders, created folder structure uses display names for game titles and publishers
- added the -v argument for toggling verify step functionality
- added the -sas argument for specifying that you wish to skip downloading files above a size threshold (for disk saving)
- various small improvements like using one call to os.makedirs() vs multiple os.mkdir() calls
- patched an issue where download keys weren't being inherited properly by game objects as they were being appended to the library list, preventing downloads

