### PR TITLE
Human Friendly naming option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,10 @@ itch-download -k KEYHERE -j 4
 
 # only download osx or cross platform downloads
 itch-download -p osx
+
+# folder structure uses display names for users/publishers and game titles
+itch-download --human-folders
+
 ```
 
 ## Add All Games in a bundle to your library

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -19,7 +19,6 @@ def main():
     )
 
     parser.add_argument(
-        "-h",
         "--human-folders",
         type=bool,
         default=False,

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -19,6 +19,16 @@ def main():
     )
 
     parser.add_argument(
+        "-h",
+        "--human-folders",
+        type=bool,
+        default=False,
+        const=True,
+        nargs='?',
+        help="Download Folders are named based on the full text version of the title instead of the trimmed URL title"
+    )
+
+    parser.add_argument(
         "-j",
         "--jobs",
         type=int,

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -14,7 +14,7 @@ class Game:
 
     def __init__(self, data):
         self.args = argv[1:]
-        if '-h' in self.args or '--human-folders' in self.args:
+        if '--human-folders' in self.args:
             self.humanFolders = True
         else:
             self.humanFolders = False

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -4,6 +4,7 @@ import urllib
 import datetime
 from pathlib import Path
 import requests
+from sys import argv
 
 from itchiodl import utils
 
@@ -12,6 +13,12 @@ class Game:
     """Representation of a game download"""
 
     def __init__(self, data):
+        self.args = argv[1:]
+        if '-h' in self.args or '--human-folders' in self.args:
+            self.humanFolders = True
+        else:
+            self.humanFolders = False
+
         self.data = data["game"]
         self.name = self.data["title"]
         self.publisher = self.data["user"]["username"]
@@ -25,7 +32,15 @@ class Game:
 
         matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
         self.game_slug = matches.group(2)
-        self.publisher_slug = matches.group(1)
+        if self.humanFolders:
+            self.name = utils.clean_path(self.data["title"])
+            self.publisher_slug = self.data.get("user").get("display_name")
+            # This Branch covers the case that the user has not set a display name, and defaults to their username
+            if not self.publisher_slug:
+                self.publisher_slug = self.data.get("user").get("username")
+        else:
+            self.name = self.game_slug
+            self.publisher_slug = matches.group(1)
 
         self.files = []
         self.downloads = []

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -33,13 +33,12 @@ class Game:
         matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
         self.game_slug = matches.group(2)
         if self.humanFolders:
-            self.name = utils.clean_path(self.data["title"])
+            self.game_slug = utils.clean_path(self.data["title"])
             self.publisher_slug = self.data.get("user").get("display_name")
             # This Branch covers the case that the user has not set a display name, and defaults to their username
             if not self.publisher_slug:
                 self.publisher_slug = self.data.get("user").get("username")
         else:
-            self.name = self.game_slug
             self.publisher_slug = matches.group(1)
 
         self.files = []

--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -41,6 +41,8 @@ def clean_path(path):
     """Cleans a path on windows"""
     if sys.platform in ["win32", "cygwin", "msys"]:
         path_clean = re.sub(r"[<>:|?*\"\/\\]", "-", path)
+        # This checks for strings that end in ... or similar, weird corner case that affects fewer than 0.1% of titles
+        path_clean = re.sub(r'(.)[.]\1+$', "-", path_clean)
         return path_clean
     return path
 


### PR DESCRIPTION
Reviving that PR from last year and breaking off a small chunk of it, this PR adds the --human-folders option to use the display names of publishers and titles in the created folder structure, also added a bug fix to utils.clean_path() to handle titles that end in '...' 

(E.g. https://zandravandra.itch.io/substitutefamiliar) <- this title still doesn't download correctly because free downloads don't seem to be parsed to game.py correctly atm but that's a separate concern for a different PR.