### PR TITLE
Clean the path the same way on all platforms

### DIFF
--- a/itchiodl/utils.py
+++ b/itchiodl/utils.py
@@ -1,5 +1,4 @@
 import re
-import sys
 import hashlib
 import requests
 
@@ -38,14 +37,12 @@ def download(url, path, name, file):
 
 
 def clean_path(path):
-    """Cleans a path on windows"""
-    if sys.platform in ["win32", "cygwin", "msys"]:
-        path_clean = re.sub(r"[<>:|?*\"\/\\]", "-", path)
-        # This checks for strings that end in ... or similar,
-        # weird corner case that affects fewer than 0.1% of titles
-        path_clean = re.sub(r"(.)[.]\1+$", "-", path_clean)
-        return path_clean
-    return path
+    """Cleans up invalid filename characters"""
+    path_clean = re.sub(r"[<>:|?*\"\/\\]", "-", path)
+    # This checks for strings that end in ... or similar,
+    # weird corner case that affects fewer than 0.1% of titles
+    path_clean = re.sub(r"(.)[.]\1+$", "-", path_clean)
+    return path_clean
 
 
 def md5sum(path):


### PR DESCRIPTION
I was testing `--human-folders` on Linux and ran into an issue where game names that contain a forward slash (`/`) would be broken up into multiple folders. So I removed the platform check in `clean_path()`.

This is also better for compatibility. It's rare, but this allows someone to move their folders to different platforms. Since the files/folders are now created the same on all platform, the user won't accidentally re-download files if they run this project on multiple platforms.