### PR TITLE
Fix issue where `--download-game` throws an error when downloading free games

### DIFF
--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -49,11 +49,16 @@ class Library:
         j = json.loads(rsp.text)
         game_id = j["id"]
         gsp = requests.get(
-            f"https://api.itch.io/games/{game_id}/uploads",
+            f"https://api.itch.io/games/{game_id}",
             headers={"Authorization": self.login},
         )
         k = gsp.json()
-        if k != {"uploads": {}}:
+        usp = requests.get(
+            f"https://api.itch.io/games/{game_id}/uploads",
+            headers={"Authorization": self.login},
+        )
+        l = usp.json()
+        if l != {"uploads": {}}:
             self.games.append(Game(k))
             return
         print(f"{title} is a purchased game.")


### PR DESCRIPTION
Downloading of free games stopped working.

Running `itch-download --download-game "https://nomnomnami.itch.io/charm-studies" --api-key xxx` returns the following error:

```
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/itchiodl-9TtSrW0h-py3.8/bin/itch-download", line 6, in <module>
    sys.exit(main())
  File "/app/itchiodl/downloader/__main__.py", line 67, in main
    lib.load_game(matches.group(1), matches.group(2))
  File "/app/itchiodl/library.py", line 56, in load_game
    self.games.append(Game(k))
  File "/app/itchiodl/game.py", line 22, in __init__
    self.data = data["game"]
KeyError: 'game'
```

In commit c652516eec390606d81350dd6f6a1c32e52cf747 a check was added to determine if a game was not purchased. This was accomplished via the `uploads/` endpoint. Unfortunately that endpoint replaced the call to the game data endpoint that we need to download the game. This adds the game data endpoint call back in.