### PR TITLE
Allow the download directory to be different from the current working directory

### DIFF
--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -9,6 +9,16 @@ def main():
     parser = argparse.ArgumentParser(prog="python -m hstp", description="Build an ")
 
     parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default=".",
+        help=(
+            "The location to store the downloaded files, defaults to the current working directory"
+        ),
+    )
+
+    parser.add_argument(
         "-k", "--api-key", help="Use API key instead of username/password"
     )
 
@@ -58,7 +68,9 @@ def main():
     else:
         l = args.api_key
 
-    lib = itchiodl.Library(l, jobs=args.jobs, human_folders=args.human_folders)
+    lib = itchiodl.Library(
+        l, jobs=args.jobs, human_folders=args.human_folders, output_dir=args.output_dir
+    )
 
     if args.download_publisher:
         lib.load_games(args.download_publisher)

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -20,11 +20,11 @@ def main():
 
     parser.add_argument(
         "--human-folders",
-        type=bool,
-        default=False,
-        const=True,
-        nargs="?",
-        help="Download Folders are named based on the full text version of the title instead of the trimmed URL title",
+        action="store_true",
+        help=(
+            "Download Folders are named based on the full text version of the title instead of "
+            "the trimmed URL title"
+        ),
     )
 
     parser.add_argument(
@@ -58,7 +58,7 @@ def main():
     else:
         l = args.api_key
 
-    lib = itchiodl.Library(l, args.jobs)
+    lib = itchiodl.Library(l, jobs=args.jobs, human_folders=args.human_folders)
 
     if args.download_publisher:
         lib.load_games(args.download_publisher)

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -11,8 +11,9 @@ from itchiodl import utils
 class Game:
     """Representation of a game download"""
 
-    def __init__(self, data, human_folders: bool):
+    def __init__(self, data, human_folders: bool, output_dir: str):
         self.human_folders = human_folders
+        self.output_path = Path(output_dir)
 
         self.data = data["game"]
         self.name = self.data["title"]
@@ -40,7 +41,7 @@ class Game:
         self.files = []
         self.downloads = []
         self.dir = (
-            Path(".")
+            self.output_path
             / utils.clean_path(self.publisher_slug)
             / utils.clean_path(self.game_slug)
         )

--- a/itchiodl/game.py
+++ b/itchiodl/game.py
@@ -3,7 +3,6 @@ import json
 import urllib
 import datetime
 from pathlib import Path
-from sys import argv
 import requests
 
 from itchiodl import utils
@@ -12,12 +11,8 @@ from itchiodl import utils
 class Game:
     """Representation of a game download"""
 
-    def __init__(self, data):
-        self.args = argv[1:]
-        if "--human-folders" in self.args:
-            self.humanFolders = True
-        else:
-            self.humanFolders = False
+    def __init__(self, data, human_folders: bool):
+        self.human_folders = human_folders
 
         self.data = data["game"]
         self.name = self.data["title"]
@@ -32,7 +27,7 @@ class Game:
 
         matches = re.match(r"https://(.+)\.itch\.io/(.+)", self.link)
         self.game_slug = matches.group(2)
-        if self.humanFolders:
+        if self.human_folders:
             self.game_slug = utils.clean_path(self.data["title"])
             self.publisher_slug = self.data.get("user").get("display_name")
             # This Branch covers the case that the user has

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -16,8 +16,10 @@ class Library:
         self.login = login
         self.games = []
         self.jobs = jobs
-        self.human_folders = human_folders
-        self.output_dir = output_dir
+        self.game_kwargs = {
+            "human_folders": human_folders,
+            "output_dir": output_dir,
+        }
 
     def load_game_page(self, page):
         """Load a page of games via the API"""
@@ -29,7 +31,7 @@ class Library:
         j = json.loads(r.text)
 
         for s in j["owned_keys"]:
-            self.games.append(Game(s, self.human_folders, self.output_dir))
+            self.games.append(Game(s, **self.game_kwargs))
 
         return len(j["owned_keys"])
 
@@ -56,7 +58,7 @@ class Library:
         )
         k = gsp.json()
         if k != {"uploads": {}}:
-            self.games.append(Game(k, self.human_folders, self.output_dir))
+            self.games.append(Game(k, **self.game_kwargs))
             return
         print(f"{title} is a purchased game.")
         i = 1
@@ -87,7 +89,7 @@ class Library:
                 headers={"Authorization": self.login},
             )
             k = json.loads(gsp.text)
-            self.games.append(Game(k, self.human_folders, self.output_dir))
+            self.games.append(Game(k, **self.game_kwargs))
 
     def download_library(self, platform=None):
         """Download all games in the library"""

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -12,10 +12,11 @@ from itchiodl.utils import NoDownloadError
 class Library:
     """Representation of a user's game library"""
 
-    def __init__(self, login, jobs=4):
+    def __init__(self, login, jobs=4, human_folders=False):
         self.login = login
         self.games = []
         self.jobs = jobs
+        self.human_folders = human_folders
 
     def load_game_page(self, page):
         """Load a page of games via the API"""
@@ -27,7 +28,7 @@ class Library:
         j = json.loads(r.text)
 
         for s in j["owned_keys"]:
-            self.games.append(Game(s))
+            self.games.append(Game(s, self.human_folders))
 
         return len(j["owned_keys"])
 
@@ -54,7 +55,7 @@ class Library:
         )
         k = gsp.json()
         if k != {"uploads": {}}:
-            self.games.append(Game(k))
+            self.games.append(Game(k, self.human_folders))
             return
         print(f"{title} is a purchased game.")
         i = 1
@@ -85,7 +86,7 @@ class Library:
                 headers={"Authorization": self.login},
             )
             k = json.loads(gsp.text)
-            self.games.append(Game(k))
+            self.games.append(Game(k, self.human_folders))
 
     def download_library(self, platform=None):
         """Download all games in the library"""

--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -12,11 +12,12 @@ from itchiodl.utils import NoDownloadError
 class Library:
     """Representation of a user's game library"""
 
-    def __init__(self, login, jobs=4, human_folders=False):
+    def __init__(self, login, jobs=4, human_folders=False, output_dir="."):
         self.login = login
         self.games = []
         self.jobs = jobs
         self.human_folders = human_folders
+        self.output_dir = output_dir
 
     def load_game_page(self, page):
         """Load a page of games via the API"""
@@ -28,7 +29,7 @@ class Library:
         j = json.loads(r.text)
 
         for s in j["owned_keys"]:
-            self.games.append(Game(s, self.human_folders))
+            self.games.append(Game(s, self.human_folders, self.output_dir))
 
         return len(j["owned_keys"])
 
@@ -55,7 +56,7 @@ class Library:
         )
         k = gsp.json()
         if k != {"uploads": {}}:
-            self.games.append(Game(k, self.human_folders))
+            self.games.append(Game(k, self.human_folders, self.output_dir))
             return
         print(f"{title} is a purchased game.")
         i = 1
@@ -86,7 +87,7 @@ class Library:
                 headers={"Authorization": self.login},
             )
             k = json.loads(gsp.text)
-            self.games.append(Game(k, self.human_folders))
+            self.games.append(Game(k, self.human_folders, self.output_dir))
 
     def download_library(self, platform=None):
         """Download all games in the library"""


### PR DESCRIPTION
Allow the download directory to be different from the current working directory. This makes it easier to run this as a cron job in Linux.

----

This PR also contains some clean ups to the `--human-folders` parameter.

Remove the need for the `Game` class to parse `sys.argv`. We'll store the option in the `Library` class and pass it to `Game` as needed.

Update the `ArgumentParser.add_argument()` call to make `--human-folders` a proper on/off flag.

Fix the naming convention for `humanFolders`. According to Python's PEP 8 Style Guide, function and variable names should be lowercase with words separated by underscores (aka snake_case). The rest of this project seems to follow PEP 8, so `humanFolders` should be `human_folders`.