### PR TITLE
Various improvements to `--help`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
         pip install poetry
         poetry install
     - name: Analysing the code with pylint
-      run: poetry run pylint --rcfile=.pylintrc itchiodl/
+      run: poetry run pylint --rcfile=.pylintrc itchiodl/ itchiodl/downloader/ itchiodl/bundle_tool/

--- a/itchiodl/bundle_tool/__main__.py
+++ b/itchiodl/bundle_tool/__main__.py
@@ -3,6 +3,8 @@ import itchiodl
 
 
 def main():
+    """CLI tool to at all games in a bundle to your library."""
+
     user = input("Username: ")
     password = getpass("Password: ")
 

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -21,7 +21,7 @@ def main():
         "--platform",
         help=(
             "Platform to download for (default: all), will accept values like 'windows', 'linux', "
-            "'osx' and android"
+            "'osx' and 'android'"
         ),
     )
 

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -6,6 +6,8 @@ import itchiodl
 
 
 def main():
+    """CLI tool to download all games in your library."""
+
     parser = argparse.ArgumentParser(
         prog="itch-download", description="Download / archive your itch.io library."
     )
@@ -17,7 +19,10 @@ def main():
     parser.add_argument(
         "-p",
         "--platform",
-        help="Platform to download for (default: all), will accept values like 'windows', 'linux', 'osx' and android",
+        help=(
+            "Platform to download for (default: all), will accept values like 'windows', 'linux', "
+            "'osx' and android"
+        ),
     )
 
     parser.add_argument(
@@ -26,7 +31,10 @@ def main():
         default=False,
         const=True,
         nargs="?",
-        help="Download Folders are named based on the full text version of the title instead of the trimmed URL title",
+        help=(
+            "Download Folders are named based on the full text version of the title instead of "
+            "the trimmed URL title"
+        ),
     )
 
     parser.add_argument(

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -6,7 +6,9 @@ import itchiodl
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="python -m hstp", description="Build an ")
+    parser = argparse.ArgumentParser(
+        prog="itch-download", description="Download / archive your itch.io library."
+    )
 
     parser.add_argument(
         "-k", "--api-key", help="Use API key instead of username/password"

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -27,10 +27,7 @@ def main():
 
     parser.add_argument(
         "--human-folders",
-        type=bool,
-        default=False,
-        const=True,
-        nargs="?",
+        action='store_true',
         help=(
             "Download Folders are named based on the full text version of the title instead of "
             "the trimmed URL title"

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -46,7 +46,7 @@ def main():
     parser.add_argument(
         "--download-game",
         type=str,
-        help="Download a specific game, should be in the format publisher.itch.io/game",
+        help="Download a specific game, should be in the format 'https://publisher.itch.io/game'",
     )
 
     args = parser.parse_args()

--- a/itchiodl/downloader/__main__.py
+++ b/itchiodl/downloader/__main__.py
@@ -27,7 +27,7 @@ def main():
 
     parser.add_argument(
         "--human-folders",
-        action='store_true',
+        action="store_true",
         help=(
             "Download Folders are named based on the full text version of the title instead of "
             "the trimmed URL title"


### PR DESCRIPTION
Update the output of `--help` so it returns `itch-download` as the program name, and returns an accurate description of what the program does.

Make it clear `https://` needs to exist to download a specific game via `--download-game`.

Add missing docstring to the `main()` function of the two CLI tools.

Limit the length of strings to satisfy `pylint`.

Keep consistent style when listing platform types for `--platform`.

Make `--human-folders` a proper on/off flag.