### PR TITLE
Use the `json()` method of the `requests` library instead of `json.loads()`

### DIFF
--- a/itchiodl/library.py
+++ b/itchiodl/library.py
@@ -1,4 +1,3 @@
-import json
 from concurrent.futures import ThreadPoolExecutor
 import functools
 import threading
@@ -24,7 +23,7 @@ class Library:
             f"https://api.itch.io/profile/owned-keys?page={page}",
             headers={"Authorization": self.login},
         )
-        j = json.loads(r.text)
+        j = r.json()
 
         for s in j["owned_keys"]:
             self.games.append(Game(s))
@@ -46,7 +45,7 @@ class Library:
             f"https://{publisher}.itch.io/{title}/data.json",
             headers={"Authorization": self.login},
         )
-        j = json.loads(rsp.text)
+        j = rsp.json()
         game_id = j["id"]
         gsp = requests.get(
             f"https://api.itch.io/games/{game_id}/uploads",
@@ -84,7 +83,7 @@ class Library:
                 f"https://api.itch.io/games/{game_id}",
                 headers={"Authorization": self.login},
             )
-            k = json.loads(gsp.text)
+            k = gsp.json()
             self.games.append(Game(k))
 
     def download_library(self, platform=None):

--- a/itchiodl/login.py
+++ b/itchiodl/login.py
@@ -1,4 +1,3 @@
-import json
 from bs4 import BeautifulSoup as soup
 import requests
 
@@ -41,7 +40,7 @@ def LoginAPI(user, password):
         print(warning)
         print(r.text)
         raise RuntimeError
-    t = json.loads(r.text)
+    t = r.json()
 
     if not t["success"]:
         print("Error: success key is not true")


### PR DESCRIPTION
I'm a stickler for consistency and I noticed that sometimes we are using `r.json()` and other times `json.loads()` . Since `requests` already supports JSON, I don't think it is necessary to import `json` as well. This PR makes the change to use the `json()` method of the `requests` library instead of `json.loads()`. 